### PR TITLE
sort attributes for consistent output

### DIFF
--- a/feedgenerator/django/utils/feedgenerator.py
+++ b/feedgenerator/django/utils/feedgenerator.py
@@ -24,7 +24,6 @@ http://web.archive.org/web/20110718035220/http://diveintomark.org/archives/2004/
 from __future__ import unicode_literals
 
 import datetime
-import collections
 try:
     from urllib.parse import urlparse
 except ImportError:     # Python 2
@@ -221,10 +220,8 @@ class RssFeed(SyndicationFeed):
         handler.endElement("rss")
 
     def rss_attributes(self):
-        d = collections.OrderedDict()
-        d["xmlns:atom"] = "http://www.w3.org/2005/Atom"
-        d["version"] = self._version
-        return d
+        return {'xmlns:atom': 'http://www.w3.org/2005/Atom',
+                'version': self._version}
 
     def write_items(self, handler):
         for item in self.items:

--- a/feedgenerator/django/utils/xmlutils.py
+++ b/feedgenerator/django/utils/xmlutils.py
@@ -2,7 +2,7 @@
 Utilities for XML generation/parsing.
 """
 
-from xml.sax.saxutils import XMLGenerator
+from xml.sax.saxutils import XMLGenerator, quoteattr
 
 class SimplerXMLGenerator(XMLGenerator):
     def addQuickElement(self, name, contents=None, attrs=None):
@@ -12,3 +12,10 @@ class SimplerXMLGenerator(XMLGenerator):
         if contents is not None:
             self.characters(contents)
         self.endElement(name)
+
+    def startElement(self, name, attrs):
+        self._write('<' + name)
+        # sort attributes for consistent output
+        for (name, value) in sorted(attrs.items()):
+            self._write(' %s=%s' % (name, quoteattr(value)))
+        self._write('>')

--- a/tests_feedgenerator/test_feedgenerator.py
+++ b/tests_feedgenerator/test_feedgenerator.py
@@ -29,7 +29,7 @@ FIXT_ITEM = dict(
 
 
 EXPECTED_RESULT = """<?xml version="1.0" encoding="utf-8"?>
-<rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0"><channel><title>Poynter E-Media Tidbits</title><link>http://www.poynter.org/column.asp?id=31</link><description>A group Weblog by the sharpest minds in online media/journalism/publishing.
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom"><channel><title>Poynter E-Media Tidbits</title><link>http://www.poynter.org/column.asp?id=31</link><description>A group Weblog by the sharpest minds in online media/journalism/publishing.
     Umlauts: äöüßÄÖÜ
     Chinese: 老师是四十四，是不是？
     Finnish: Mustan kissan paksut posket. (ah, no special chars) Kärpänen sanoi kärpäselle: tuu kattoon kattoon ku kaveri tapettiin tapettiin.

--- a/tests_feedgenerator/test_stringio.py
+++ b/tests_feedgenerator/test_stringio.py
@@ -15,7 +15,7 @@ ENCODING = 'utf-8'
 S0 = 'hello world, Umlauts: äöüßÄÖÜ, Chinese: 四是四，十是十，十四是十四，四十是四十，四十四隻不識字之石獅子是死的'
 S0_BYTES = 'fe fi foe fam'.encode(ENCODING)
 
-print("###", StringIO, "###")
+#print("###", StringIO, "###")
 
 class TestStringIO(unittest.TestCase):
 


### PR DESCRIPTION
Adds an override for `startElement` so that the attributes written in sorted order. This eliminates the arbitrary order of `dict` iteration while writing items attributes and provides consistent output. This was the source of issue getpelican/pelican#729 and getpelican/pelican#688.
