### PR TITLE
draft to add image to rss feeds

### DIFF
--- a/feedgenerator/django/utils/feedgenerator.py
+++ b/feedgenerator/django/utils/feedgenerator.py
@@ -86,7 +86,7 @@ class SyndicationFeed(object):
     "Base class for all syndication feeds. Subclasses should provide write()"
     def __init__(self, title, link, description, language=None, author_email=None,
             author_name=None, author_link=None, subtitle=None, categories=None,
-            feed_url=None, feed_copyright=None, feed_guid=None, ttl=None, **kwargs):
+            feed_url=None, feed_copyright=None, image=None, feed_guid=None, ttl=None, **kwargs):
         to_unicode = lambda s: force_text(s, strings_only=True)
         if categories:
             categories = [force_text(c) for c in categories]
@@ -105,6 +105,7 @@ class SyndicationFeed(object):
             'categories': categories or (),
             'feed_url': iri_to_uri(feed_url),
             'feed_copyright': to_unicode(feed_copyright),
+            'image': iri_to_uri(image),
             'id': feed_guid or link,
             'ttl': ttl,
         }
@@ -232,6 +233,12 @@ class RssFeed(SyndicationFeed):
     def add_root_elements(self, handler):
         handler.addQuickElement("title", self.feed['title'])
         handler.addQuickElement("link", self.feed['link'])
+        if self.feed['image'] is not None:
+            handler.startElement(u'image', {})
+            handler.addQuickElement(u"url", self.feed['link']+self.feed['image'])
+            handler.addQuickElement(u"title", self.feed['title'])
+            handler.addQuickElement(u"link", self.feed['link'])
+            handler.endElement(u'image')
         handler.addQuickElement("description", self.feed['description'])
         if self.feed['feed_url'] is not None:
             handler.addQuickElement("atom:link", None,

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ CLASSIFIERS = ['Development Status :: 3 - Alpha',
                'Programming Language :: Python',
                'Programming Language :: Python :: 2.7',
                'Programming Language :: Python :: 3.2',
+               'Programming Language :: Python :: 3.3',
                'Topic :: Internet :: WWW/HTTP',
                'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
                'Topic :: Software Development :: Libraries :: Python Modules',
@@ -30,11 +31,11 @@ AUTHOR_EMAIL = 'foundation@djangoproject.com'
 MAINTAINER = 'Dirk Makowski'
 MAINTAINER_EMAIL = 'dm@parenchym.com'
 KEYWORDS = "feed atom rss".split(' ')
-VERSION = '1.5.dev'
+VERSION = '1.7'
 
 TEST_SUITE = 'tests_feedgenerator'
 
-REQUIRES = ['pytz', 'six']
+REQUIRES = ['pytz >= 0a', 'six']
 
 setup(
     name=NAME,


### PR DESCRIPTION
essentially i'm copy and pasteing this:
http://stackoverflow.com/questions/660836/django-way-of-specifying-channel-image-in-rss-feed

though it sure needs tuning of how the image url is assembled - at the moment i just concatenate the feedurl with what's in "image" w/o checking if "image" is already a full url - possibly hosted somewhere else.
